### PR TITLE
Support for Appium8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ defaultTasks 'check', 'test', 'publishToMavenLocal'
 
 group = 'com.codeborne'
 description = 'Selenide adaptor for Appium framework'
-version = '1.7.4'
+version = '1.7.5'
 
 tasks.withType(Test) {
   useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ defaultTasks 'check', 'test', 'publishToMavenLocal'
 
 group = 'com.codeborne'
 description = 'Selenide adaptor for Appium framework'
-version = '1.7.5'
+version = '1.8.0-beta'
 
 tasks.withType(Test) {
   useJUnitPlatform()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  api('com.codeborne:selenide:5.25.1')
-  api('io.appium:java-client:7.6.0')
+  api('com.codeborne:selenide:6.3.4')
+  api('io.appium:java-client:8.0.0')
   implementation('commons-io:commons-io:2.11.0')
   testImplementation('org.junit.jupiter:junit-jupiter:5.8.1')
   testImplementation('org.assertj:assertj-core:3.21.0')

--- a/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -35,10 +35,10 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   }
 
   private DefaultElementByBuilder byBuilder(Driver driver) {
-    if (driver instanceof HasBrowserCheck && !((HasBrowserCheck) driver.getWebDriver()).isBrowser()) {
+    if (driver.getWebDriver() instanceof HasBrowserCheck && ((HasBrowserCheck) driver.getWebDriver()).isBrowser()) {
       return new DefaultElementByBuilder(null, null);
     } else {
-      Capabilities d = ((RemoteWebDriver) driver).getCapabilities();
+      Capabilities d = ((RemoteWebDriver) driver.getWebDriver()).getCapabilities();
       return new DefaultElementByBuilder(d.getPlatformName().toString(), d.getCapability(AUTOMATION_NAME_OPTION).toString());
     }
   }

--- a/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
@@ -2,7 +2,7 @@ package com.codeborne.selenide.appium.commands;
 
 import com.codeborne.selenide.commands.Click;
 import com.codeborne.selenide.impl.WebElementSource;
-import io.appium.java_client.MobileDriver;
+import io.appium.java_client.AppiumDriver;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -15,7 +15,7 @@ public class AppiumClick extends Click {
   @Nonnull
   @CheckReturnValue
   protected WebElement findElement(WebElementSource locator) {
-    if (locator.driver().getWebDriver() instanceof MobileDriver) {
+    if (locator.driver().getWebDriver() instanceof AppiumDriver) {
       return locator.getWebElement();
     }
     else {

--- a/src/test/java/com/codeborne/selenide/appium/AndroidDriverProvider.java
+++ b/src/test/java/com/codeborne/selenide/appium/AndroidDriverProvider.java
@@ -2,22 +2,17 @@ package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.WebDriverProvider;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.options.UiAutomator2Options;
+import io.appium.java_client.remote.AutomationName;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 
-import static io.appium.java_client.remote.AndroidMobileCapabilityType.APP_ACTIVITY;
-import static io.appium.java_client.remote.AndroidMobileCapabilityType.APP_PACKAGE;
-import static io.appium.java_client.remote.MobileCapabilityType.DEVICE_NAME;
-import static io.appium.java_client.remote.MobileCapabilityType.FULL_RESET;
-import static io.appium.java_client.remote.MobileCapabilityType.NEW_COMMAND_TIMEOUT;
-import static io.appium.java_client.remote.MobileCapabilityType.PLATFORM_NAME;
-import static io.appium.java_client.remote.MobileCapabilityType.VERSION;
 import static org.openqa.selenium.remote.CapabilityType.APPLICATION_NAME;
 
 public class AndroidDriverProvider implements WebDriverProvider {
@@ -25,18 +20,19 @@ public class AndroidDriverProvider implements WebDriverProvider {
   @Nonnull
   @Override
   public WebDriver createDriver(@Nonnull Capabilities capabilities) {
-    DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
-    desiredCapabilities.merge(capabilities);
-    desiredCapabilities.setCapability(PLATFORM_NAME, "Android");
-    desiredCapabilities.setCapability(DEVICE_NAME, "Android Emulator");
-    desiredCapabilities.setCapability(VERSION, "9.0");
-    desiredCapabilities.setCapability(APPLICATION_NAME, "Appium");
-    desiredCapabilities.setCapability(APP_PACKAGE, "com.android.calculator2");
-    desiredCapabilities.setCapability(APP_ACTIVITY, "com.android.calculator2.Calculator");
-    desiredCapabilities.setCapability(NEW_COMMAND_TIMEOUT, 11);
-    desiredCapabilities.setCapability(FULL_RESET, false);
+    UiAutomator2Options options = new UiAutomator2Options();
+    options.merge(capabilities);
+    options.setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+    options.setPlatformName("Android");
+    options.setDeviceName("Android Emulator");
+    options.setPlatformVersion("9.0");
+    options.setCapability(APPLICATION_NAME, "Appium");
+    options.setAppPackage("com.android.calculator2");
+    options.setAppActivity("com.android.calculator2.Calculator");
+    options.setNewCommandTimeout(Duration.ofSeconds(11));
+    options.setFullReset(false);
     try {
-      return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), desiredCapabilities);
+      return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), options);
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/codeborne/selenide/appium/AndroidDriverProvider.java
+++ b/src/test/java/com/codeborne/selenide/appium/AndroidDriverProvider.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.WebDriverProvider;
 import io.appium.java_client.android.AndroidDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -23,17 +24,19 @@ public class AndroidDriverProvider implements WebDriverProvider {
   @CheckReturnValue
   @Nonnull
   @Override
-  public WebDriver createDriver(DesiredCapabilities capabilities) {
-    capabilities.setCapability(PLATFORM_NAME, "Android");
-    capabilities.setCapability(DEVICE_NAME, "Android Emulator");
-    capabilities.setCapability(VERSION, "9.0");
-    capabilities.setCapability(APPLICATION_NAME, "Appium");
-    capabilities.setCapability(APP_PACKAGE, "com.android.calculator2");
-    capabilities.setCapability(APP_ACTIVITY, "com.android.calculator2.Calculator");
-    capabilities.setCapability(NEW_COMMAND_TIMEOUT, 11);
-    capabilities.setCapability(FULL_RESET, false);
+  public WebDriver createDriver(@Nonnull Capabilities capabilities) {
+    DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
+    desiredCapabilities.merge(capabilities);
+    desiredCapabilities.setCapability(PLATFORM_NAME, "Android");
+    desiredCapabilities.setCapability(DEVICE_NAME, "Android Emulator");
+    desiredCapabilities.setCapability(VERSION, "9.0");
+    desiredCapabilities.setCapability(APPLICATION_NAME, "Appium");
+    desiredCapabilities.setCapability(APP_PACKAGE, "com.android.calculator2");
+    desiredCapabilities.setCapability(APP_ACTIVITY, "com.android.calculator2.Calculator");
+    desiredCapabilities.setCapability(NEW_COMMAND_TIMEOUT, 11);
+    desiredCapabilities.setCapability(FULL_RESET, false);
     try {
-      return new AndroidDriver<>(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
+      return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), desiredCapabilities);
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/codeborne/selenide/appium/demos/AbstractApiDemosTest.java
+++ b/src/test/java/com/codeborne/selenide/appium/demos/AbstractApiDemosTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.appium.demos;
 
 import com.codeborne.selenide.Configuration;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidElement;
 import org.junit.jupiter.api.BeforeEach;
 
 import static com.codeborne.selenide.Selenide.closeWebDriver;
@@ -13,14 +12,13 @@ public abstract class AbstractApiDemosTest {
   @BeforeEach
   public void setUp() {
     closeWebDriver();
-    Configuration.startMaximized = false;
     Configuration.browserSize = null;
     Configuration.browser = AndroidDriverWithDemos.class.getName();
     open();
   }
 
   @SuppressWarnings("unchecked")
-  protected AndroidDriver<AndroidElement> driver() {
-    return (AndroidDriver<AndroidElement>) getWebDriver();
+  protected AndroidDriver driver() {
+    return (AndroidDriver) getWebDriver();
   }
 }

--- a/src/test/java/com/codeborne/selenide/appium/demos/AndroidDriverWithDemos.java
+++ b/src/test/java/com/codeborne/selenide/appium/demos/AndroidDriverWithDemos.java
@@ -2,11 +2,12 @@ package com.codeborne.selenide.appium.demos;
 
 import com.codeborne.selenide.WebDriverProvider;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.android.options.UiAutomator2Options;
+import io.appium.java_client.remote.AutomationName;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
@@ -15,39 +16,43 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
+import static org.openqa.selenium.remote.CapabilityType.APPLICATION_NAME;
 
 public class AndroidDriverWithDemos implements WebDriverProvider {
-    @Override
-    public WebDriver createDriver(@Nonnull Capabilities capabilities) {
-        File app = downloadApk();
-        DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
-        desiredCapabilities.merge(capabilities);
-        desiredCapabilities.setCapability(MobileCapabilityType.VERSION, "4.4.2");
-        desiredCapabilities.setCapability("automationName", "Appium");
-        desiredCapabilities.setCapability("platformName", "Android");
-        desiredCapabilities.setCapability("deviceName", "Android Emulator");
-        desiredCapabilities.setCapability("app", app.getAbsolutePath());
-        desiredCapabilities.setCapability("appPackage", "io.appium.android.apis");
-        desiredCapabilities.setCapability("appActivity", ".ApiDemos");
+  @CheckReturnValue
+  @Nonnull
+  @Override
+  public WebDriver createDriver(@Nonnull Capabilities capabilities) {
+    File app = downloadApk();
 
-        try {
-            return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), desiredCapabilities);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    UiAutomator2Options options = new UiAutomator2Options();
+    options.merge(capabilities);
+    options.setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+    options.setPlatformName("Android");
+    options.setDeviceName("Android Emulator");
+    options.setPlatformVersion("4.4.2");
+    options.setCapability(APPLICATION_NAME, "Appium");
+    options.setApp(app.getAbsolutePath());
+    options.setAppPackage("io.appium.android.apis");
+    options.setAppActivity(".ApiDemos");
 
-    private File downloadApk() {
-        File apk = new File("build/ApiDemos-debug.apk");
-        if (!apk.exists()) {
-            String url = "https://github.com/appium/sample-code/blob/master/sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk?raw=true";
-            try (InputStream in = new URL(url).openStream()) {
-                copyInputStreamToFile(in, apk);
-            }
-            catch (IOException e) {
-                throw new AssertionError("Failed to download apk", e);
-            }
-        }
-        return apk;
+    try {
+      return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), options);
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
     }
+  }
+
+  private File downloadApk() {
+    File apk = new File("build/ApiDemos-debug.apk");
+    if (!apk.exists()) {
+      String url = "https://github.com/appium/sample-code/blob/master/sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk?raw=true";
+      try (InputStream in = new URL(url).openStream()) {
+        copyInputStreamToFile(in, apk);
+      } catch (IOException e) {
+        throw new AssertionError("Failed to download apk", e);
+      }
+    }
+    return apk;
+  }
 }

--- a/src/test/java/com/codeborne/selenide/appium/demos/AndroidDriverWithDemos.java
+++ b/src/test/java/com/codeborne/selenide/appium/demos/AndroidDriverWithDemos.java
@@ -2,11 +2,12 @@ package com.codeborne.selenide.appium.demos;
 
 import com.codeborne.selenide.WebDriverProvider;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidElement;
 import io.appium.java_client.remote.MobileCapabilityType;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,18 +18,20 @@ import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
 
 public class AndroidDriverWithDemos implements WebDriverProvider {
     @Override
-    public WebDriver createDriver(DesiredCapabilities capabilities) {
+    public WebDriver createDriver(@Nonnull Capabilities capabilities) {
         File app = downloadApk();
-        capabilities.setCapability(MobileCapabilityType.VERSION, "4.4.2");
-        capabilities.setCapability("automationName", "Appium");
-        capabilities.setCapability("platformName", "Android");
-        capabilities.setCapability("deviceName", "Android Emulator");
-        capabilities.setCapability("app", app.getAbsolutePath());
-        capabilities.setCapability("appPackage", "io.appium.android.apis");
-        capabilities.setCapability("appActivity", ".ApiDemos");
+        DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
+        desiredCapabilities.merge(capabilities);
+        desiredCapabilities.setCapability(MobileCapabilityType.VERSION, "4.4.2");
+        desiredCapabilities.setCapability("automationName", "Appium");
+        desiredCapabilities.setCapability("platformName", "Android");
+        desiredCapabilities.setCapability("deviceName", "Android Emulator");
+        desiredCapabilities.setCapability("app", app.getAbsolutePath());
+        desiredCapabilities.setCapability("appPackage", "io.appium.android.apis");
+        desiredCapabilities.setCapability("appActivity", ".ApiDemos");
 
         try {
-            return new AndroidDriver<AndroidElement>(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
+            return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), desiredCapabilities);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
In general there was not much to update, followed the Appium 7.x to 8.x migration guide.

Changes:
* MobileDriver -> AppiumDriver
* MobileElement -> WebElement (as the MobileElement is removed)
* DesiredCapabilities -> UiAutomator2Options
* changes in SelenideAppiumPageFactory.DefaultElementByBuilder (please carefully review, altho I tested this, changes here are bit wider) 
* dependencies updated, using selenide 6.3.4, appium 8.0.0
* version bump to 1.8.0-beta