### PR TITLE
#88 Don't try to describe element when NoSuchElementException

### DIFF
--- a/src/main/java/com/codeborne/selenide/appium/AppiumElementDescriber.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumElementDescriber.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.impl.ElementDescriber;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
@@ -116,7 +117,7 @@ public class AppiumElementDescriber implements ElementDescriber {
     private String tagName = "?";
     private String text = "?";
     private final StringBuilder sb = new StringBuilder();
-    private StaleElementReferenceException staleElementException;
+    private WebDriverException unforgivableException;
 
     private Builder(WebElement element, WebDriver webDriver, List<String> supportedAttributes) {
       this.element = element;
@@ -156,7 +157,7 @@ public class AppiumElementDescriber implements ElementDescriber {
     }
 
     private void safeCall(Supplier<String> method, Supplier<String> errorMessage, Consumer<String> resultHandler) {
-      if (staleElementException != null) return;
+      if (unforgivableException != null) return;
 
       try {
         String value = method.get();
@@ -164,8 +165,8 @@ public class AppiumElementDescriber implements ElementDescriber {
           resultHandler.accept(value);
         }
       }
-      catch (StaleElementReferenceException e) {
-        staleElementException = e;
+      catch (StaleElementReferenceException | NoSuchElementException e) {
+        unforgivableException = e;
         logger.debug("{}: {}", errorMessage.get(), e.toString());
       }
       catch (WebDriverException e) {
@@ -184,8 +185,8 @@ public class AppiumElementDescriber implements ElementDescriber {
     public Builder finish() {
       sb.append(">");
 
-      if (staleElementException != null) {
-        sb.append(staleElementException);
+      if (unforgivableException != null) {
+        sb.append(unforgivableException);
       }
       else {
         appendText();


### PR DESCRIPTION
## Proposed changes
Avoid spam and useless calls to webdriver
```
[INFO] 2022-11-28 10:05:44,592 [AppiumElementDescriber]: Failed to get attribute class: org.openqa.selenium.NoSuchElementException: Can't locate an element by this strategy: By.chained({By.xpath: //android.widget.Button[@text='Not Now']})
[INFO] 2022-11-28 10:05:46,949 [AppiumElementDescriber]: Failed to get tag name: org.openqa.selenium.NoSuchElementException: Can't locate an element by this strategy: By.chained({By.xpath: //android.widget.Button[@text='Not Now']})
[INFO] 2022-11-28 10:05:48,398 [AppiumElementDescriber]: Failed to get attribute resource-id: org.openqa.selenium.NoSuchElementException: Can't locate an element by this strategy: By.chained({By.xpath: //android.widget.Button[@text='Not Now']})
```


## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
