### PR TITLE
Remove unsupported xcuitest resource-id attribute.

### DIFF
--- a/src/main/java/com/codeborne/selenide/appium/AppiumElementDescriber.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumElementDescriber.java
@@ -92,7 +92,6 @@ public class AppiumElementDescriber implements ElementDescriber {
   public String briefly(Driver driver, @Nonnull WebElement element) {
     return new Builder(element, driver.getWebDriver(), supportedAttributes(driver))
       .appendTagName()
-      .appendAttribute("resource-id")
       .finish()
       .build();
   }

--- a/src/test/java/com/codeborne/selenide/appium/AppiumElementDescriberTest.java
+++ b/src/test/java/com/codeborne/selenide/appium/AppiumElementDescriberTest.java
@@ -96,18 +96,6 @@ public class AppiumElementDescriberTest {
   }
 
   @Test
-  public void addsElementId() {
-    givenAndroidDriver();
-    when(element.getAttribute("class")).thenReturn("android.widget.TextView");
-    when(element.getAttribute("className")).thenReturn("android.widget.TextView");
-    when(element.getAttribute("text")).thenReturn("Hello, world");
-    when(element.getAttribute("resource-id")).thenReturn("submitPaymentButton");
-
-    assertThat(describer.briefly(driver, element))
-      .isEqualTo("<TextView resource-id=\"submitPaymentButton\">Hello, world</TextView>");
-  }
-
-  @Test
   public void fully() {
     givenAndroidDriver();
     when(element.getAttribute("class")).thenReturn("android.widget.TextView");


### PR DESCRIPTION
There is no recource-id in https://github.com/appium/appium-xcuitest-driver#element-attributes

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
