### PR TITLE
Added AppiumSetValueOptions to hide keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ boolean isAndroid = AppiumDriverRunner.isAndroidDriver();
 boolean isIos = AppiumDriverRunner.isIosDriver();
 ```
 
+5. Wish to hide keyboard after entering value to textbox
+
+```
+$(AppiumBy.accessibilityId("Username input field"))
+      .shouldBe(visible)
+      .setValue(withText("abcd").hideKeyboard());
+```
 ### Changelog
 
 Here is [CHANGELOG](https://github.com/selenide/selenide-appium/blob/main/CHANGELOG)

--- a/src/main/java/com/codeborne/selenide/appium/AppiumSetValueOptions.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumSetValueOptions.java
@@ -1,0 +1,29 @@
+package com.codeborne.selenide.appium;
+
+public class AppiumSetValueOptions {
+
+  private final CharSequence value;
+  private boolean shouldHideKeyboard;
+
+  private AppiumSetValueOptions(CharSequence value, boolean shouldHideKeyboard) {
+    this.value = value;
+    this.shouldHideKeyboard = shouldHideKeyboard;
+  }
+
+  public static AppiumSetValueOptions withText(CharSequence textToEnter) {
+    return new AppiumSetValueOptions(textToEnter, false);
+  }
+
+  public void hideKeyboard() {
+    this.shouldHideKeyboard = true;
+  }
+
+  public CharSequence value() {
+    return value;
+  }
+
+  public boolean shouldHideKeyboard() {
+    return shouldHideKeyboard;
+  }
+
+}

--- a/src/main/java/com/codeborne/selenide/appium/AppiumSetValueOptions.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumSetValueOptions.java
@@ -1,12 +1,14 @@
 package com.codeborne.selenide.appium;
 
-public class AppiumSetValueOptions {
+import com.codeborne.selenide.SetValueMethod;
+import com.codeborne.selenide.SetValueOptions;
 
-  private final CharSequence value;
+public class AppiumSetValueOptions extends SetValueOptions {
+
   private boolean shouldHideKeyboard;
 
   private AppiumSetValueOptions(CharSequence value, boolean shouldHideKeyboard) {
-    this.value = value;
+    super(SetValueMethod.SEND_KEYS, value, value);
     this.shouldHideKeyboard = shouldHideKeyboard;
   }
 
@@ -14,12 +16,9 @@ public class AppiumSetValueOptions {
     return new AppiumSetValueOptions(textToEnter, false);
   }
 
-  public void hideKeyboard() {
+  public AppiumSetValueOptions hideKeyboard() {
     this.shouldHideKeyboard = true;
-  }
-
-  public CharSequence value() {
-    return value;
+    return this;
   }
 
   public boolean shouldHideKeyboard() {

--- a/src/main/java/com/codeborne/selenide/appium/commands/AppiumSetValue.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/AppiumSetValue.java
@@ -32,7 +32,11 @@ public class AppiumSetValue implements Command<SelenideElement> {
       element.sendKeys(text);
 
       if (appiumSetValueOptions.shouldHideKeyboard()) {
-        hideKeyBoard();
+        if (AppiumDriverRunner.isAndroidDriver()) {
+          hideKeyBoardForAndroid();
+        } else if (AppiumDriverRunner.isIosDriver()) {
+          hideKeyBoardForIos(proxy);
+        }
       }
       return proxy;
     } else {
@@ -49,11 +53,15 @@ public class AppiumSetValue implements Command<SelenideElement> {
     }
   }
 
-  private void hideKeyBoard() {
-    if (AppiumDriverRunner.isAndroidDriver() && AppiumDriverRunner.getAndroidDriver().isKeyboardShown()) {
+  private void hideKeyBoardForAndroid() {
+    if (AppiumDriverRunner.getAndroidDriver().isKeyboardShown()) {
       AppiumDriverRunner.getAndroidDriver().hideKeyboard();
-    } else if (AppiumDriverRunner.isIosDriver() && AppiumDriverRunner.getIosDriver().isKeyboardShown()) {
-      AppiumDriverRunner.getIosDriver().hideKeyboard();
+    }
+  }
+
+  private void hideKeyBoardForIos(SelenideElement proxy) {
+    if (AppiumDriverRunner.getIosDriver().isKeyboardShown()) {
+      proxy.sendKeys("\n");
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/appium/commands/AppiumSetValue.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/AppiumSetValue.java
@@ -2,6 +2,8 @@ package com.codeborne.selenide.appium.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.AppiumDriverRunner;
+import com.codeborne.selenide.appium.AppiumSetValueOptions;
 import com.codeborne.selenide.commands.SetValue;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
@@ -11,7 +13,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.appium.WebdriverUnwrapper.isMobile;
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.codeborne.selenide.commands.Util.firstOf;
 import static java.util.Objects.requireNonNull;
 
 @ParametersAreNonnullByDefault
@@ -23,13 +25,35 @@ public class AppiumSetValue implements Command<SelenideElement> {
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     if (isMobile(locator.driver())) {
       WebElement element = locator.findAndAssertElementIsInteractable();
-      CharSequence text = firstNonNull((CharSequence) requireNonNull(args)[0], "");
+      AppiumSetValueOptions appiumSetValueOptions = extractOptions(requireNonNull(args));
+
+      CharSequence text = requireNonNull(appiumSetValueOptions.value());
       element.clear();
       element.sendKeys(text);
+
+      if (appiumSetValueOptions.shouldHideKeyboard()) {
+        hideKeyBoard();
+      }
       return proxy;
-    }
-    else {
+    } else {
       return defaultImplementation.execute(proxy, locator, args);
+    }
+  }
+
+  private AppiumSetValueOptions extractOptions(Object[] args) {
+    if (args[0] instanceof AppiumSetValueOptions) {
+      return (AppiumSetValueOptions) args[0];
+    } else {
+      CharSequence text = firstOf(args);
+      return AppiumSetValueOptions.withText(text);
+    }
+  }
+
+  private void hideKeyBoard() {
+    if (AppiumDriverRunner.isAndroidDriver() && AppiumDriverRunner.getAndroidDriver().isKeyboardShown()) {
+      AppiumDriverRunner.getAndroidDriver().hideKeyboard();
+    } else if (AppiumDriverRunner.isIosDriver() && AppiumDriverRunner.getIosDriver().isKeyboardShown()) {
+      AppiumDriverRunner.getIosDriver().hideKeyboard();
     }
   }
 }

--- a/src/test/java/integration/android/AndroidSetValueOptionsTest.java
+++ b/src/test/java/integration/android/AndroidSetValueOptionsTest.java
@@ -1,25 +1,17 @@
 package integration.android;
 
-import com.codeborne.selenide.SetValueOptions;
-import com.codeborne.selenide.appium.AppiumSetValueOptions;
 import com.codeborne.selenide.appium.SelenideAppium;
 import io.appium.java_client.AppiumBy;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.appium.AppiumSelectors.byText;
-import static io.appium.java_client.AppiumBy.xpath;
 
 class AndroidSetValueOptionsTest extends BaseSwagLabsAndroidTest {
 
   @Test
   void testHideKeyboardForAndroid() {
-    SelenideAppium.launchApp();
-
-    $(xpath("//android.view.ViewGroup[@content-desc='open menu']/android.widget.ImageView"))
-      .shouldBe(visible).click();
-    $(byText("Log In")).shouldBe(visible).click();
+    SelenideAppium.openAndroidDeepLink("mydemoapprn://login", "com.saucelabs.mydemoapp.rn");
     $(AppiumBy.accessibilityId("Username input field")).shouldBe(visible);
       //.setValue(AppiumSetValueOptions.withText("abcd123").hideKeyboard());
   }

--- a/src/test/java/integration/android/AndroidSetValueOptionsTest.java
+++ b/src/test/java/integration/android/AndroidSetValueOptionsTest.java
@@ -1,0 +1,26 @@
+package integration.android;
+
+import com.codeborne.selenide.SetValueOptions;
+import com.codeborne.selenide.appium.AppiumSetValueOptions;
+import com.codeborne.selenide.appium.SelenideAppium;
+import io.appium.java_client.AppiumBy;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.appium.AppiumSelectors.byText;
+import static io.appium.java_client.AppiumBy.xpath;
+
+class AndroidSetValueOptionsTest extends BaseSwagLabsAndroidTest {
+
+  @Test
+  void testHideKeyboardForAndroid() {
+    SelenideAppium.launchApp();
+
+    $(xpath("//android.view.ViewGroup[@content-desc='open menu']/android.widget.ImageView"))
+      .shouldBe(visible).click();
+    $(byText("Log In")).shouldBe(visible).click();
+    $(AppiumBy.accessibilityId("Username input field")).shouldBe(visible);
+      //.setValue(AppiumSetValueOptions.withText("abcd123").hideKeyboard());
+  }
+}

--- a/src/test/java/integration/ios/IosSetValueOptionsTest.java
+++ b/src/test/java/integration/ios/IosSetValueOptionsTest.java
@@ -22,11 +22,9 @@ class IosSetValueOptionsTest extends BaseSwagLabsAppIosTest {
       .click(AppiumClickOptions.tap())
       .setValue(AppiumSetValueOptions.withText("abcd").hideKeyboard());
 
-    Thread.sleep(3_000);
+    $(AppiumBy.accessibilityId("Username input field")).shouldHave(text("abcd"));
     assertThat(AppiumDriverRunner.getIosDriver().isKeyboardShown())
       .isFalse();
-
-    $(AppiumBy.accessibilityId("Username input field")).shouldHave(text("abcd"));
   }
 
   @Test
@@ -37,9 +35,8 @@ class IosSetValueOptionsTest extends BaseSwagLabsAppIosTest {
       .click(AppiumClickOptions.tap())
       .setValue(AppiumSetValueOptions.withText("abcd"));
 
-    Thread.sleep(2_000);
+    $(AppiumBy.accessibilityId("Username input field")).shouldHave(text("abcd"));
     assertThat(AppiumDriverRunner.getIosDriver().isKeyboardShown())
       .isTrue();
-    $(AppiumBy.accessibilityId("Username input field")).shouldHave(text("abcd"));
   }
 }

--- a/src/test/java/integration/ios/IosSetValueOptionsTest.java
+++ b/src/test/java/integration/ios/IosSetValueOptionsTest.java
@@ -1,4 +1,4 @@
-package integration.android;
+package integration.ios;
 
 import com.codeborne.selenide.appium.AppiumClickOptions;
 import com.codeborne.selenide.appium.AppiumDriverRunner;
@@ -12,31 +12,33 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AndroidSetValueOptionsTest extends BaseSwagLabsAndroidTest {
+class IosSetValueOptionsTest extends BaseSwagLabsAppIosTest {
 
   @Test
-  void testHideKeyboardForAndroid() {
-    SelenideAppium.openAndroidDeepLink("mydemoapprn://login", "com.saucelabs.mydemoapp.rn");
+  void testHideKeyboardForIos() throws InterruptedException {
+    SelenideAppium.openIOSDeepLink("mydemoapprn://login");
     $(AppiumBy.accessibilityId("Username input field"))
       .shouldBe(visible)
       .click(AppiumClickOptions.tap())
       .setValue(AppiumSetValueOptions.withText("abcd").hideKeyboard());
 
-    assertThat(AppiumDriverRunner.getAndroidDriver().isKeyboardShown())
+    Thread.sleep(3_000);
+    assertThat(AppiumDriverRunner.getIosDriver().isKeyboardShown())
       .isFalse();
 
     $(AppiumBy.accessibilityId("Username input field")).shouldHave(text("abcd"));
   }
 
   @Test
-  void testSetValueOptionsForAndroid() {
-    SelenideAppium.openAndroidDeepLink("mydemoapprn://login", "com.saucelabs.mydemoapp.rn");
+  void testSetValueOptionsForIos() throws InterruptedException {
+    SelenideAppium.openIOSDeepLink("mydemoapprn://login");
     $(AppiumBy.accessibilityId("Username input field"))
       .shouldBe(visible)
       .click(AppiumClickOptions.tap())
       .setValue(AppiumSetValueOptions.withText("abcd"));
 
-    assertThat(AppiumDriverRunner.getAndroidDriver().isKeyboardShown())
+    Thread.sleep(2_000);
+    assertThat(AppiumDriverRunner.getIosDriver().isKeyboardShown())
       .isTrue();
     $(AppiumBy.accessibilityId("Username input field")).shouldHave(text("abcd"));
   }


### PR DESCRIPTION
Added AppiumSetValueOptions to hide keyboard if needed after setting value to textbox.

It is a painful process to hide keyboard after every setValue. Hiding keyboard is not needed always. It is needed only if the screen size is small or element is at bottom of the screen. 

So we want to leave the choice to users.

$(element).setValue(withText("abcd123").hideKeyboard());
$(element).setValue(withText("abcd123"));
$(element).setValue("abcd123");

@BorisOsipov 

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
