### PR TITLE
#125 run tests on Java11, not Java8.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '8'
+          distribution: 'temurin'
+          cache: 'gradle'
+          java-version: '11'
       - uses: actions/cache@v3
         with:
           path: |
@@ -145,8 +146,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '8'
+          distribution: 'temurin'
+          cache: 'gradle'
+          java-version: '11'
       - name: Run iOS tests
         run: ./gradlew ios --no-daemon --console=plain -i
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          cache: 'gradle'
+          java-version: '11'
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Since version 5.0.0, Mockito requires Java11 or higher.
