### PR TITLE
try not to Install Haxm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - name: Install Haxm
-        run: brew install --cask intel-haxm
       - name: Install Appium
         run: |
           npm install -g appium@next


### PR DESCRIPTION
it fails on github actions server:

```
Run brew install --cask intel-haxm
==> Caveats
intel-haxm requires a kernel extension to work.
If the installation fails, retry after you enable it in:
  System Preferences → Security & Privacy → General

For more information, refer to vendor documentation or this Apple Technical Note:
  https://developer.apple.com/library/content/technotes/tn2459/_index.html

==> Downloading https://github.com/intel/haxm/releases/download/v7.8.0/haxm-macosx_v7_8_0.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/98257850/49aae6ec-50c0-49e7-b11e-3d26c5462b13?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230131T213316Z&X-Amz-Expires=300&X-Amz-Signature=aae7d8d28502e733ebf2c23fab6d588c2be1669ae1971d6289bb724b27c29a85&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=98257850&response-content-disposition=attachment%3B%20filename%3Dhaxm-macosx_v7_8_0.zip&response-content-type=application%2Foctet-stream
Error: SHA256 mismatch
Expected: 4d30b68eccd31a8534d976e884de8e728746bf1d568912af23c894c8818481c6
  Actual: 44059b3ad33de87562ecd7a6c5a003dce96aa51506667752601467af7b328c29
    File: /Users/runner/Library/Caches/Homebrew/downloads/1662603e2ad7cd976ee422fbe3ad7cdcfb558fc002db6cb24cc73e53e9191dbf--haxm-macosx_v7_8_0.zip
To retry an incomplete download, remove the file above.
Error: Process completed with exit code 1.
```

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
