### PR TITLE
Add scroll in mobile using scroll directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,19 @@ boolean isAndroid = AppiumDriverRunner.isAndroidDriver();
 boolean isIos = AppiumDriverRunner.isIosDriver();
 ```
 
+5. We handle the scrolling for you
+
+```java
+$(By.xpath(".//*[@text='Tabs']")).scrollTo().click(); //scroll max of 30 times in downward direction to find element
+$(By.xpath(".//*[@text='Tabs']")).scroll(with(DOWN, 10)); //scroll max of 10 times in downward direction to find element
+$(By.xpath(".//*[@text='Animation']")).scroll(up()); //scroll max of 30 times in upward direction to find element
+```
 ### Changelog
 
 Here is [CHANGELOG](https://github.com/selenide/selenide-appium/blob/main/CHANGELOG)
 
 ### Reference
 
-Please check our [sample project](https://github.com/selenide-examples/selenide-appium). 
+Please check our [sample project](https://github.com/selenide-examples/selenide-appium).
+
 Please check our [simple skeleton framework](https://github.com/amuthansakthivel/SelenideAppiumFramework)

--- a/src/main/java/com/codeborne/selenide/appium/AppiumScrollCoordinates.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumScrollCoordinates.java
@@ -1,0 +1,32 @@
+package com.codeborne.selenide.appium;
+
+public class AppiumScrollCoordinates {
+
+  private final int startX;
+  private final int startY;
+  private final int endX;
+  private final int endY;
+
+  public AppiumScrollCoordinates(int startX, int startY, int endX, int endY) {
+    this.startX = startX;
+    this.startY = startY;
+    this.endX = endX;
+    this.endY = endY;
+  }
+
+  public int getStartX() {
+    return startX;
+  }
+
+  public int getStartY() {
+    return startY;
+  }
+
+  public int getEndX() {
+    return endX;
+  }
+
+  public int getEndY() {
+    return endY;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
@@ -31,10 +31,6 @@ public class AppiumScrollOptions {
     return new AppiumScrollOptions(ScrollDirection.UP, maxSwipeCounts);
   }
 
-  public static AppiumScrollOptions withDirection(ScrollDirection scrollDirection) {
-    return new AppiumScrollOptions(scrollDirection, DEFAULT_MAX_SWIPE_COUNTS);
-  }
-
   public int getMaxSwipeCounts() {
     return maxSwipeCounts;
   }

--- a/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
+++ b/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
@@ -1,0 +1,46 @@
+package com.codeborne.selenide.appium;
+
+public class AppiumScrollOptions {
+
+  private final ScrollDirection scrollDirection;
+  private final int maxSwipeCounts;
+  private static final int DEFAULT_MAX_SWIPE_COUNTS = 30;
+
+  private AppiumScrollOptions(ScrollDirection scrollDirection, int maxSwipeCounts) {
+    this.scrollDirection = scrollDirection;
+    this.maxSwipeCounts = maxSwipeCounts;
+  }
+
+  public static AppiumScrollOptions with(ScrollDirection scrollDirection, int maxSwipeCounts) {
+    return new AppiumScrollOptions(scrollDirection, maxSwipeCounts);
+  }
+
+  public static AppiumScrollOptions down() {
+    return new AppiumScrollOptions(ScrollDirection.DOWN, DEFAULT_MAX_SWIPE_COUNTS);
+  }
+
+  public static AppiumScrollOptions down(int maxSwipeCounts) {
+    return new AppiumScrollOptions(ScrollDirection.DOWN, maxSwipeCounts);
+  }
+
+  public static AppiumScrollOptions up() {
+    return new AppiumScrollOptions(ScrollDirection.UP, DEFAULT_MAX_SWIPE_COUNTS);
+  }
+
+  public static AppiumScrollOptions up(int maxSwipeCounts) {
+    return new AppiumScrollOptions(ScrollDirection.UP, maxSwipeCounts);
+  }
+
+  public static AppiumScrollOptions withDirection(ScrollDirection scrollDirection) {
+    return new AppiumScrollOptions(scrollDirection, DEFAULT_MAX_SWIPE_COUNTS);
+  }
+
+  public int getMaxSwipeCounts() {
+    return maxSwipeCounts;
+  }
+
+  public ScrollDirection getScrollDirection() {
+    return scrollDirection;
+  }
+
+}

--- a/src/main/java/com/codeborne/selenide/appium/ScrollDirection.java
+++ b/src/main/java/com/codeborne/selenide/appium/ScrollDirection.java
@@ -1,0 +1,6 @@
+package com.codeborne.selenide.appium;
+
+public enum ScrollDirection {
+  UP,
+  DOWN
+}

--- a/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -19,6 +19,10 @@ public class SelenideAppium {
   private static final AppiumNavigator appiumNavigator = new AppiumNavigator();
   private static final DeepLinkLauncher deepLinkLauncher = new DeepLinkLauncher();
 
+  private SelenideAppium() {
+
+  }
+
   /**
    * The main starting point in your tests.
    * Launch a mobile application. Do nothing if driver already created.
@@ -62,18 +66,6 @@ public class SelenideAppium {
    */
   public static void back() {
     Selenide.back();
-  }
-
-  @CheckReturnValue
-  @Nonnull
-  public static SelenideAppiumElement $(String cssSelector) {
-    return $(cssSelector, 0);
-  }
-
-  @CheckReturnValue
-  @Nonnull
-  public static SelenideAppiumElement $(String cssSelector, int index) {
-    return $(By.cssSelector(cssSelector), index);
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
+++ b/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
@@ -4,4 +4,6 @@ import com.codeborne.selenide.SelenideElement;
 
 public interface SelenideAppiumElement extends SelenideElement {
   SelenideAppiumElement hideKeyboard();
+  SelenideAppiumElement scrollTo();
+  SelenideAppiumElement scroll(AppiumScrollOptions appiumScrollOptions);
 }

--- a/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
@@ -82,9 +82,11 @@ public class AppiumScrollTo implements Command<SelenideAppiumElement> {
 
   private AppiumScrollCoordinates getScrollCoordinates(AppiumScrollOptions scrollOptions, Dimension size) {
     if (scrollOptions.getScrollDirection() == ScrollDirection.UP) {
-      return new AppiumScrollCoordinates(size.getWidth() / 2, (int) (size.getHeight() * 0.25), size.getWidth() / 2, size.getHeight() / 2);
+      return new AppiumScrollCoordinates(size.getWidth() / 2, (int) (size.getHeight() * 0.25),
+                                         size.getWidth() / 2, size.getHeight() / 2);
     } else {
-      return new AppiumScrollCoordinates(size.getWidth() / 2, size.getHeight() / 2, size.getWidth() / 2, (int) (size.getHeight() * 0.25));
+      return new AppiumScrollCoordinates(size.getWidth() / 2, size.getHeight() / 2,
+                                         size.getWidth() / 2, (int) (size.getHeight() * 0.25));
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
@@ -1,0 +1,101 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.AppiumScrollCoordinates;
+import com.codeborne.selenide.appium.AppiumScrollOptions;
+import com.codeborne.selenide.appium.ScrollDirection;
+import com.codeborne.selenide.appium.SelenideAppiumElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+import static com.codeborne.selenide.appium.WebdriverUnwrapper.cast;
+import static com.codeborne.selenide.commands.Util.firstOf;
+import static java.time.Duration.ofMillis;
+import static java.util.Collections.singletonList;
+
+public class AppiumScrollTo implements Command<SelenideAppiumElement> {
+
+  @Override
+  @Nonnull
+  public SelenideAppiumElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+    AppiumDriver appiumDriver = cast(locator.driver(), AppiumDriver.class)
+      .orElseThrow(() -> new IllegalStateException("Driver should be either an instance of Android or Ios Driver"));
+
+    AppiumScrollOptions appiumScrollOptions;
+
+    if (args == null || args.length == 0) {
+      appiumScrollOptions = AppiumScrollOptions.with(ScrollDirection.DOWN, 30);
+    } else if (args.length == 1) {
+      appiumScrollOptions = firstOf(args);
+    } else {
+      throw new IllegalArgumentException("Unsupported scroll arguments: " + Arrays.toString(args));
+    }
+    int currentSwipeCount = 0;
+    String previousPageSource = "";
+
+    while (isElementNotDisplayed(locator)
+      && isNotEndOfPage(appiumDriver, previousPageSource)
+      && isLessThanMaxSwipeCount(currentSwipeCount, appiumScrollOptions.getMaxSwipeCounts())) {
+      previousPageSource = appiumDriver.getPageSource();
+      performScroll(appiumDriver, appiumScrollOptions);
+      currentSwipeCount++;
+    }
+    return (SelenideAppiumElement) proxy;
+  }
+
+  private boolean isLessThanMaxSwipeCount(int currentSwipeCount, int maxSwipeCounts) {
+    return currentSwipeCount < maxSwipeCounts;
+  }
+
+  private boolean isElementNotDisplayed(WebElementSource locator) {
+    try {
+      return !locator.getWebElement().isDisplayed();
+    } catch (NoSuchElementException noSuchElementException) {
+      return true;
+    }
+  }
+
+  private boolean isNotEndOfPage(AppiumDriver appiumDriver, String initialPageSource) {
+    return !initialPageSource.equals(appiumDriver.getPageSource());
+  }
+
+  private Dimension getMobileDeviceSize(AppiumDriver appiumDriver) {
+    return appiumDriver.manage().window().getSize();
+  }
+
+  private void performScroll(AppiumDriver appiumDriver, AppiumScrollOptions scrollOptions) {
+    Dimension size = getMobileDeviceSize(appiumDriver);
+    AppiumScrollCoordinates scrollCoordinates = getScrollCoordinates(scrollOptions, size);
+    PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+    Sequence sequenceToPerformScroll = getSequenceToPerformScroll(finger, scrollCoordinates);
+    appiumDriver.perform(singletonList(sequenceToPerformScroll));
+  }
+
+  private AppiumScrollCoordinates getScrollCoordinates(AppiumScrollOptions scrollOptions, Dimension size) {
+    if (scrollOptions.getScrollDirection() == ScrollDirection.UP) {
+      return new AppiumScrollCoordinates(size.getWidth() / 2, (int) (size.getHeight() * 0.25), size.getWidth() / 2, size.getHeight() / 2);
+    } else {
+      return new AppiumScrollCoordinates(size.getWidth() / 2, size.getHeight() / 2, size.getWidth() / 2, (int) (size.getHeight() * 0.25));
+    }
+  }
+
+  private Sequence getSequenceToPerformScroll(PointerInput finger, AppiumScrollCoordinates scrollCoordinates) {
+    return new Sequence(finger, 1)
+      .addAction(finger.createPointerMove(ofMillis(0),
+                                          PointerInput.Origin.viewport(), scrollCoordinates.getStartX(), scrollCoordinates.getStartY()))
+      .addAction(finger.createPointerDown(PointerInput.MouseButton.MIDDLE.asArg()))
+      .addAction(finger.createPointerMove(ofMillis(200),
+                                          PointerInput.Origin.viewport(), scrollCoordinates.getEndX(), scrollCoordinates.getEndY()))
+      .addAction(finger.createPointerUp(PointerInput.MouseButton.MIDDLE.asArg()));
+  }
+}
+

--- a/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
@@ -13,5 +13,7 @@ public class SelenideAppiumCommands extends Commands {
     add("setValue", new AppiumSetValue());
     add("val", new AppiumVal());
     add("hideKeyboard", new HideKeyboard());
+    add("scrollTo", new AppiumScrollTo());
+    add("scroll", new AppiumScrollTo());
   }
 }

--- a/src/test/java/integration/android/AndroidScrollTest.java
+++ b/src/test/java/integration/android/AndroidScrollTest.java
@@ -1,0 +1,41 @@
+package integration.android;
+
+
+import com.codeborne.selenide.appium.SelenideAppium;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
+import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
+import static com.codeborne.selenide.appium.AppiumScrollOptions.with;
+import static com.codeborne.selenide.appium.ScrollDirection.DOWN;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
+
+class AndroidScrollTest extends BaseApiDemosTest {
+
+  @BeforeEach
+  void setUp() {
+    closeWebDriver();
+    SelenideAppium.launchApp();
+  }
+
+  @Test
+  void testScrollToElement() {
+    $(By.xpath(".//*[@text='Views']")).click();
+    $(By.xpath(".//*[@text='Tabs']")).scrollTo().click();
+    $(By.xpath(".//*[@text='1. Content By Id']"))
+      .shouldHave(visible);
+  }
+
+  @Test
+  void testAndroidScrollOptions() {
+    $(By.xpath(".//*[@text='Views']")).click();
+    $(By.xpath(".//*[@text='Tabs']"))
+      .scroll(with(DOWN, 10));
+    $(By.xpath(".//*[@text='Animation']"))
+      .scroll(up())
+      .shouldHave(visible);
+  }
+}

--- a/src/test/java/integration/ios/IosScrollTest.java
+++ b/src/test/java/integration/ios/IosScrollTest.java
@@ -1,0 +1,17 @@
+package integration.ios;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.appium.SelenideAppium.$x;
+
+class IosScrollTest extends BaseSwagLabsAppIosTest {
+
+  @Test
+  void testScrollToElementOnIos() {
+
+    $x("//XCUIElementTypeStaticText[@name='© 2023 Sauce Labs. All Rights Reserved. Terms of Service | Privacy Policy.']")
+      .scrollTo()
+      .shouldHave(visible);
+  }
+}


### PR DESCRIPTION
## Proposed changes
Added code to scroll to element

```java
$(By.xpath(".//*[@text='Tabs']")).scrollTo().click(); //scroll max of 30 times in downward direction to find element
$(By.xpath(".//*[@text='Tabs']")).scroll(with(DOWN, 10)); //scroll max of 10 times in downward direction to find element
$(By.xpath(".//*[@text='Animation']")).scroll(up()); //scroll max of 30 times in upward direction to find element
```

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
