### PR TITLE
find element based on android or ios driver

### DIFF
--- a/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -86,4 +86,11 @@ public class SelenideAppium {
     return ElementFinder.wrap(driver(), SelenideAppiumElement.class, null, seleniumSelector, index);
   }
 
+  @CheckReturnValue
+  @Nonnull
+  public static SelenideAppiumElement $(By androidSelector, By iosSelector) {
+    return AppiumDriverRunner.isAndroidDriver()
+      ? $(androidSelector, 0)
+      : $(iosSelector, 0);
+  }
 }

--- a/src/test/java/integration/android/AndroidSelectorsTest.java
+++ b/src/test/java/integration/android/AndroidSelectorsTest.java
@@ -20,6 +20,7 @@ import static com.codeborne.selenide.appium.SelenideAppium.back;
 import com.codeborne.selenide.appium.SelenideAppium;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 
 class AndroidSelectorsTest extends BaseApiDemosTest {
 
@@ -56,7 +57,7 @@ class AndroidSelectorsTest extends BaseApiDemosTest {
     back();
     $(withTagAndText("android.widget.TextView", GRAPHICS_PARTIAL_STRING)).click();
     back();
-    $(withText(GRAPHICS_PARTIAL_STRING))
+    SelenideAppium.$(withText(GRAPHICS_PARTIAL_STRING), By.xpath(""))
       .shouldHave(text("Graphics"));
   }
 }


### PR DESCRIPTION
## Proposed changes
It is very common to use By and String locating strategies in automation. (Common reasons are to use dynamic locating strategy or to leverage AppiumSelectors).

In case of mobile app, that has both android and ios apps - we have to write locators like

String androidLocator = "//*[@text='%s']"
String iosLocator = "//*[@label='%s']"

```java
public void clickMenu(String menuName){
  By locator = getLocatorBasedOnOs(By.xpath(String.format(androidLocator, menuName)), 
                       By.xpath(String.format(iosLocator, menuName)));
  $(locator).click()
}

public By getLocatorBasedOnOs(By androidLocator, By iosLocator){
  return AppiumDriverRunner.isAndroidDriver ? androidLocator : iosLocator;
}
```

Instead of doing all these, going forward we can use something like
SelenideAppium.$(androidBy, iosBy).click();

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
