### PR TITLE
introduce class MobileBy to pass selectors for both Android and iOS

### DIFF
--- a/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -85,12 +85,4 @@ public class SelenideAppium {
   public static SelenideAppiumElement $(By seleniumSelector, int index) {
     return ElementFinder.wrap(driver(), SelenideAppiumElement.class, null, seleniumSelector, index);
   }
-
-  @CheckReturnValue
-  @Nonnull
-  public static SelenideAppiumElement $(By androidSelector, By iosSelector) {
-    return AppiumDriverRunner.isAndroidDriver()
-      ? $(androidSelector, 0)
-      : $(iosSelector, 0);
-  }
 }

--- a/src/main/java/com/codeborne/selenide/appium/selector/CombinedBy.java
+++ b/src/main/java/com/codeborne/selenide/appium/selector/CombinedBy.java
@@ -14,24 +14,24 @@ import static com.codeborne.selenide.appium.AppiumDriverRunner.isIosDriver;
 import static java.util.Objects.requireNonNull;
 
 @ParametersAreNonnullByDefault
-public class MobileBy extends By {
+public class CombinedBy extends By {
   @Nullable
-  private By androidSelector;
+  private final By androidSelector;
 
   @Nullable
-  private By iosSelector;
+  private final By iosSelector;
 
-  private MobileBy(@Nullable By androidSelector, @Nullable By iosSelector) {
+  private CombinedBy(@Nullable By androidSelector, @Nullable By iosSelector) {
     this.androidSelector = androidSelector;
     this.iosSelector = iosSelector;
   }
 
-  public static MobileBy android(By android) {
-    return new MobileBy(android, null);
+  public static CombinedBy android(By android) {
+    return new CombinedBy(android, null);
   }
 
-  public MobileBy ios(By ios) {
-    return new MobileBy(androidSelector, ios);
+  public CombinedBy ios(By ios) {
+    return new CombinedBy(androidSelector, ios);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/appium/selector/MobileBy.java
+++ b/src/main/java/com/codeborne/selenide/appium/selector/MobileBy.java
@@ -1,0 +1,56 @@
+package com.codeborne.selenide.appium.selector;
+
+import com.codeborne.selenide.WebDriverRunner;
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+
+import static com.codeborne.selenide.appium.AppiumDriverRunner.isAndroidDriver;
+import static com.codeborne.selenide.appium.AppiumDriverRunner.isIosDriver;
+import static java.util.Objects.requireNonNull;
+
+@ParametersAreNonnullByDefault
+public class MobileBy extends By {
+  @Nullable
+  private By androidSelector;
+
+  @Nullable
+  private By iosSelector;
+
+  private MobileBy(@Nullable By androidSelector, @Nullable By iosSelector) {
+    this.androidSelector = androidSelector;
+    this.iosSelector = iosSelector;
+  }
+
+  public static MobileBy android(By android) {
+    return new MobileBy(android, null);
+  }
+
+  public MobileBy ios(By ios) {
+    return new MobileBy(androidSelector, ios);
+  }
+
+  @Override
+  public WebElement findElement(SearchContext context) {
+    return chooseSelector().findElement(context);
+  }
+
+  @Override
+  public List<WebElement> findElements(SearchContext context) {
+    return chooseSelector().findElements(context);
+  }
+
+  private By chooseSelector() {
+    if (isAndroidDriver()) {
+      return requireNonNull(androidSelector, "Android selector not given");
+    }
+    if (isIosDriver()) {
+      return requireNonNull(iosSelector, "iOS selector not given");
+    }
+    throw new UnsupportedOperationException("Unsupported webdriver: " + WebDriverRunner.getWebDriver());
+  }
+}

--- a/src/test/java/integration/android/AndroidSelectorsTest.java
+++ b/src/test/java/integration/android/AndroidSelectorsTest.java
@@ -21,7 +21,7 @@ import static com.codeborne.selenide.appium.AppiumSelectors.withTagAndText;
 import static com.codeborne.selenide.appium.AppiumSelectors.withText;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.appium.SelenideAppium.back;
-import static com.codeborne.selenide.appium.selector.MobileBy.android;
+import static com.codeborne.selenide.appium.selector.CombinedBy.android;
 
 class AndroidSelectorsTest extends BaseApiDemosTest {
 

--- a/src/test/java/integration/android/AndroidSelectorsTest.java
+++ b/src/test/java/integration/android/AndroidSelectorsTest.java
@@ -1,7 +1,11 @@
 package integration.android;
 
+import com.codeborne.selenide.appium.SelenideAppium;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
 import static com.codeborne.selenide.Condition.text;
-import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.appium.AppiumSelectors.byAttribute;
 import static com.codeborne.selenide.appium.AppiumSelectors.byContentDescription;
@@ -15,12 +19,9 @@ import static com.codeborne.selenide.appium.AppiumSelectors.withTagAndAttribute;
 import static com.codeborne.selenide.appium.AppiumSelectors.withTagAndContentDescription;
 import static com.codeborne.selenide.appium.AppiumSelectors.withTagAndText;
 import static com.codeborne.selenide.appium.AppiumSelectors.withText;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.appium.SelenideAppium.back;
-
-import com.codeborne.selenide.appium.SelenideAppium;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
+import static com.codeborne.selenide.appium.selector.MobileBy.android;
 
 class AndroidSelectorsTest extends BaseApiDemosTest {
 
@@ -57,7 +58,7 @@ class AndroidSelectorsTest extends BaseApiDemosTest {
     back();
     $(withTagAndText("android.widget.TextView", GRAPHICS_PARTIAL_STRING)).click();
     back();
-    SelenideAppium.$(withText(GRAPHICS_PARTIAL_STRING), By.xpath(""))
+    $(android(withText(GRAPHICS_PARTIAL_STRING)).ios(By.xpath("")))
       .shouldHave(text("Graphics"));
   }
 }


### PR DESCRIPTION
Typical usage:

```java
$(android(By.foo).ios(By.bar))
  .shouldHave(text("Graphics"));
```

@amuthansakthivel This is how the "combined" mobile locator could look like.