### PR TITLE
fixed the slowness in the swipe/scroll in ios 

### DIFF
--- a/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
@@ -69,12 +69,9 @@ public class AppiumScrollTo implements Command<SelenideElement> {
 
   private void scrollInMobile(AppiumDriver appiumDriver, WebElementSource locator, AppiumScrollOptions scrollOptions) {
     int currentSwipeCount = 0;
-    String previousPageSource = "";
 
     while (isElementNotDisplayed(locator)
-           && isNotEndOfPage(appiumDriver, previousPageSource)
            && isLessThanMaxSwipeCount(currentSwipeCount, scrollOptions.getMaxSwipeCounts())) {
-      previousPageSource = appiumDriver.getPageSource();
       performScroll(appiumDriver, scrollOptions.getScrollDirection());
       currentSwipeCount++;
     }
@@ -90,10 +87,6 @@ public class AppiumScrollTo implements Command<SelenideElement> {
     } catch (NoSuchElementException noSuchElementException) {
       return true;
     }
-  }
-
-  private boolean isNotEndOfPage(AppiumDriver appiumDriver, String initialPageSource) {
-    return !initialPageSource.equals(appiumDriver.getPageSource());
   }
 
   private Dimension getMobileDeviceSize(AppiumDriver appiumDriver) {


### PR DESCRIPTION
## Proposed changes
Fixed issue - https://github.com/selenide/selenide-appium/issues/153

Previously we thought of using pageSource to determine whether the mobile screen have reached the bottom or top of the screen. But calling pagesource in ios causing a delay of 10seconds

https://github.com/appium/appium/issues/18665 - There is no viable and effective solution to sort this out. I tried out some options but the time to fetch pagesource is still more than 6 seconds for a call.

Hence the users can use the maxSwipes to scroll to find an element. Also pageSource was not really effective in finding whether the mobile scroll have reached the end. There is no obvious to have it in the code.

Example of how users can scroll to element and fail fast:
```java
$(By.xpath(".//*[@text='Tabs']")).scroll(with(DOWN, 10));
$(By.xpath(".//*[@text='Tabs']")).scroll(with(DOWN, 5));
```

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
